### PR TITLE
Limit log message length

### DIFF
--- a/lib/contextual_logging/logstash_message_formatter.rb
+++ b/lib/contextual_logging/logstash_message_formatter.rb
@@ -1,6 +1,7 @@
 module ContextualLogging
   class LogstashMessageFormatter
     def format(severity, message, extra_context)
+      message = message[0..1999] if severity == 'INFO'
       msg_hash = HashWithIndifferentAccess.new('message' => message, 'log_level' => severity)
       logstash_data = extra_context.merge(msg_hash)
       logstash_event = LogStash::Event.new(logstash_data)
@@ -8,4 +9,3 @@ module ContextualLogging
     end
   end
 end
-

--- a/spec/contextual_logging_spec.rb
+++ b/spec/contextual_logging_spec.rb
@@ -1,4 +1,10 @@
 require 'spec_helper'
 
-describe ContextualLogging do
+describe ContextualLogging::LogstashMessageFormatter do
+  message_formatter = ContextualLogging::LogstashMessageFormatter.new
+    it 'should limit message size to 2000 characters when severity level is INFO' do
+      message = (0...3000).map { ('a'..'z').to_a[rand(26)] }.join
+      log_message = message_formatter.format('INFO', message, {})
+      expect(eval(log_message)[:message].length).to equal 2000
+    end
 end


### PR DESCRIPTION
limited info level messages to have max length of 2000 characters